### PR TITLE
修正 Ch02 Browserify + Gulp + Babelify 的 Markdown

### DIFF
--- a/Ch02/browserify-gulp-dev-enviroment.md
+++ b/Ch02/browserify-gulp-dev-enviroment.md
@@ -32,7 +32,8 @@
 	$ npm install --save-dev babelify babel-preset-es2015 babel-preset-react
 	```
 
-	```js .babelrc
+	```js
+    // filename: .babelrc
 	{
 		"presets": [
 		  "es2015",
@@ -50,7 +51,8 @@
 
 6. 撰寫 Component
 
-	```js ./app/index.js
+	```js
+    // filename: ./app/index.js
 	import React from 'react';
 	import ReactDOM from 'react-dom';
 
@@ -72,7 +74,8 @@
 	ReactDOM.render(<App />, document.getElementById('app'));
 	```
 
-	```html ./index.html
+	```html
+    <!-- filename: ./index.html -->
 	<!DOCTYPE html>
 	<html lang="en">
 	<head>
@@ -90,7 +93,8 @@
 
 7. 設定 `gulpfile.js`
 
-	```js gulpfile.js
+	```js
+    // filename: gulpfile.js
 	// 引入所有需要的檔案
 	const gulp = require('gulp');
 	const uglify = require('gulp-uglify');


### PR DESCRIPTION
如果在 .md 中寫
```
```js filename
```
好像沒辦法被 parse 成期望的格式，
所以我把它修正為下方這種格式 :smile:
```
```js
// filename: filename
```