### PR TITLE
Update for redux-logger v3

### DIFF
--- a/Ch07/react-redux-example/src/store/configureStore.js
+++ b/Ch07/react-redux-example/src/store/configureStore.js
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
-import createLogger from 'redux-logger';
+import { createLogger } from 'redux-logger';
 import Immutable from 'immutable';
 import rootReducer from '../reducers';
 


### PR DESCRIPTION
[redux-logger v3] BREAKING CHANGE
[redux-logger v3] Since 3.0.0 redux-logger exports by default logger with default settings.
[redux-logger v3] Change
[redux-logger v3] import createLogger from 'redux-logger'
[redux-logger v3] to
[redux-logger v3] import { createLogger } from 'redux-logger'