### PR TITLE
Upgrade react-tap-event-plugin to fix the webpack compile error.

### DIFF
--- a/Ch09/react-router-redux-github-finder/package.json
+++ b/Ch09/react-router-redux-github-finder/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^15.3.0",
     "react-redux": "^4.4.5",
     "react-router": "^2.6.1",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.0",
     "redux": "^3.5.2",
     "redux-actions": "^0.10.1",
     "redux-immutable": "^3.0.7",


### PR DESCRIPTION
To fix the compiler error at Ch09.